### PR TITLE
This migration would fail due to missing index.

### DIFF
--- a/db/migrate/2_add_missing_unique_indices.rb
+++ b/db/migrate/2_add_missing_unique_indices.rb
@@ -3,7 +3,9 @@ class AddMissingUniqueIndices < ActiveRecord::Migration
     add_index :tags, :name, unique: true
 
     remove_index :taggings, :tag_id
-    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    remove_index :taggings, :taggable_id
+    remove_index :taggings, :taggable_type
+    remove_index :taggings, :context
     add_index :taggings,
               [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
               unique: true, name: 'taggings_idx'
@@ -14,6 +16,8 @@ class AddMissingUniqueIndices < ActiveRecord::Migration
 
     remove_index :taggings, name: 'taggings_idx'
     add_index :taggings, :tag_id
-    add_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings, :taggable_id
+    add_index :taggings, :taggable_type
+    add_index :taggings, :context
   end
 end


### PR DESCRIPTION
Not sure exactly what the root problem here is, but basically the 3-col multi-column index didn't exist in our db, instead we had three separate indexes, one for each column. My guess is this is due to a change between rails 2 and rails 3 syntax for specifying multi-column indexes.

In any case, we can alter the `up` part of this migration to remove the 3 indexes, and alter `down` as well so that it would be possible to ROLLBACK then migrate again, though this situation isn't ideal.
