### PR TITLE
Enable use of custom cache delimiter with `save_cached_tag_list`.

### DIFF
--- a/lib/acts_as_taggable_on/taggable/cache.rb
+++ b/lib/acts_as_taggable_on/taggable/cache.rb
@@ -73,7 +73,7 @@ module ActsAsTaggableOn::Taggable
         tag_types.map(&:to_s).each do |tag_type|
           if self.class.send("caching_#{tag_type.singularize}_list?")
             if tag_list_cache_set_on(tag_type)
-              list = tag_list_cache_on(tag_type).to_a.flatten.compact.join(', ')
+              list = tag_list_cache_on(tag_type).to_a.flatten.compact.join("#{ActsAsTaggableOn.delimiter} ")
               self["cached_#{tag_type.singularize}_list"] = list
             end
           end

--- a/spec/acts_as_taggable_on/caching_spec.rb
+++ b/spec/acts_as_taggable_on/caching_spec.rb
@@ -75,6 +75,20 @@ describe 'Acts As Taggable On' do
       CachedModel.reset_column_information
       expect(CachedModel.instance_variable_get(:@acts_as_taggable_on_cache_columns)).to eql(nil)
     end
+
+    context 'with custom delimiter' do
+      before(:each) do
+        @default_delimiter = ActsAsTaggableOn.delimiter
+        ActsAsTaggableOn.delimiter = '#'
+      end
+      after(:each) do
+        ActsAsTaggableOn.delimiter = @default_delimiter
+      end
+      it 'should use custom delimiter in the cached list' do
+        @taggable.update_attributes(:tag_list => ['awesome', 'epic'])
+        expect(@taggable.cached_tag_list).to eql('awesome# epic')
+      end
+    end
   end
 
   describe 'CachingWithArray' do


### PR DESCRIPTION
Allows us to do things like 

``` ruby
def cached_category_list_as_array
    self.cached_category_list.blank? ? [] : self.cached_category_list.split("#{ActsAsTaggableOn.delimiter}").map(&:strip)
  end
```
